### PR TITLE
Fix hook to read stored attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,10 @@
 
 * Initial release with Extended user custom field format.
 
+## 0.0.2
+
+* Added Dependable list and Dependable key/value list custom field formats.
+* Parent field must be from the same object type.
+  * List fields may depend on regular lists or other dependable lists.
+  * Key/value fields may depend on enumerations or other dependable key/value lists.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,10 @@
   * List fields may depend on regular lists or other dependable lists.
   * Key/value fields may depend on enumerations or other dependable key/value lists.
 
+## 0.0.3
+
+* Added dependency matrix to configure allowed parent/child values.
+* Child fields are disabled until a parent value is chosen and only allowed
+  values are shown. Blank options remain available for deselection and all
+  descendant fields update when parents are cleared.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redmine Depending Custom Fields
 
-This plugin provides depending / cascading custom field formats for Redmine that can be toggled via the plugin settings. Version `0.0.1` introduces an *Extended user* field format with options for group-based filtering and visibility of active, registered or inactive users.
+This plugin provides depending / cascading custom field formats for Redmine that can be toggled via the plugin settings. Version `0.0.2` introduces two new field formats (*List (dependable)* and *Key/Value list (dependable)*) in addition to the *Extended user* field format with options for group-based filtering and visibility of active, registered or inactive users.
 
 ## Features
 
@@ -8,9 +8,12 @@ This plugin provides depending / cascading custom field formats for Redmine that
    - Filter users by Redmine groups
    - Optionally exclude administrators
   - Choose to display active, registered and/or inactive users
-  - Users are listed under headers for active, registered and inactive status in filters
+ - Users are listed under headers for active, registered and inactive status in filters
 2. `Depending` or `Cascading` custom fields
    - Both for `lists` as `key/value` pairs
+   - New formats `List (dependable)` and `Key/Value list (dependable)` allow defining parent/child relationships
+   - Parent lists can depend on other lists or dependable lists of the same object type
+   - Key/value lists can depend on enumerations or dependable key/value lists of the same object type
    - `Parent` and `Child` relationships between fields
    - Relation between `Parent` and `Child` values is configurable in a matrix
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This plugin provides depending / cascading custom field formats for Redmine that
    - Key/value lists can depend on enumerations or dependable key/value lists of the same object type
    - `Parent` and `Child` relationships between fields
    - Relation between `Parent` and `Child` values is configurable in a matrix
+   - Child fields include a blank option to deselect and are disabled until a
+     parent value is chosen. Descendant fields update automatically when parents
+     are cleared and only show the allowed options
 
 ## Installation
 

--- a/app/views/custom_fields/formats/_dependable_enumeration.html.erb
+++ b/app/views/custom_fields/formats/_dependable_enumeration.html.erb
@@ -1,0 +1,21 @@
+<% unless @custom_field.new_record? %>
+<p>
+  <label><%= l(:field_possible_values) %></label>
+  <%= link_to sprite_icon('edit', l(:button_edit)), custom_field_enumerations_path(@custom_field), :class => 'icon icon-edit' %>
+</p>
+<% if @custom_field.enumerations.active.any? %>
+  <p><%= f.select :default_value, @custom_field.enumerations.active.map{|v| [v.name, v.id.to_s]}, :include_blank => true %></p>
+<% end %>
+<% end %>
+
+<p><%= f.text_field :url_pattern, :size => 50, :label => :label_link_values_to %></p>
+<p>
+  <%= f.select :parent_custom_field_id,
+               CustomField.where(field_format: ['enumeration', RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION],
+                                  type: @custom_field.type)
+                          .where.not(id: @custom_field.id)
+                          .map { |cf| [cf.name, cf.id.to_s] },
+               {include_blank: true},
+               label: :field_parent_custom_field_id %>
+</p>
+<p><%= edit_tag_style_tag f %></p>

--- a/app/views/custom_fields/formats/_dependable_enumeration.html.erb
+++ b/app/views/custom_fields/formats/_dependable_enumeration.html.erb
@@ -18,4 +18,9 @@
                {include_blank: true},
                label: :field_parent_custom_field_id %>
 </p>
+<% if @custom_field.parent_custom_field_id.present? %>
+  <% parent_cf = CustomField.find_by(id: @custom_field.parent_custom_field_id) %>
+  <%= render partial: 'custom_fields/formats/dependencies_matrix',
+             locals: {parent_field: parent_cf, custom_field: @custom_field} %>
+<% end %>
 <p><%= edit_tag_style_tag f %></p>

--- a/app/views/custom_fields/formats/_dependable_list.html.erb
+++ b/app/views/custom_fields/formats/_dependable_list.html.erb
@@ -1,0 +1,16 @@
+<p>
+  <%= f.text_area :possible_values, :value => @custom_field.possible_values.to_a.join("\n"), :rows => 15, :required => true %>
+  <em class="info"><%= l(:text_custom_field_possible_values_info) %></em>
+</p>
+<p><%= f.text_field(:default_value) %></p>
+<p><%= f.text_field :url_pattern, :size => 50, :label => :label_link_values_to %></p>
+<p>
+  <%= f.select :parent_custom_field_id,
+               CustomField.where(field_format: ['list', RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST],
+                                  type: @custom_field.type)
+                          .where.not(id: @custom_field.id)
+                          .map { |cf| [cf.name, cf.id.to_s] },
+               {include_blank: true},
+               label: :field_parent_custom_field_id %>
+</p>
+<p><%= edit_tag_style_tag f %></p>

--- a/app/views/custom_fields/formats/_dependable_list.html.erb
+++ b/app/views/custom_fields/formats/_dependable_list.html.erb
@@ -13,4 +13,9 @@
                {include_blank: true},
                label: :field_parent_custom_field_id %>
 </p>
+<% if @custom_field.parent_custom_field_id.present? %>
+  <% parent_cf = CustomField.find_by(id: @custom_field.parent_custom_field_id) %>
+  <%= render partial: 'custom_fields/formats/dependencies_matrix',
+             locals: {parent_field: parent_cf, custom_field: @custom_field} %>
+<% end %>
 <p><%= edit_tag_style_tag f %></p>

--- a/app/views/custom_fields/formats/_dependencies_matrix.html.erb
+++ b/app/views/custom_fields/formats/_dependencies_matrix.html.erb
@@ -1,0 +1,26 @@
+<% if parent_field && parent_field.possible_values.any? && custom_field.possible_values.any? %>
+<table class="list dependencies-matrix">
+  <thead>
+    <tr>
+      <th></th>
+      <% custom_field.possible_values.each do |cv| %>
+        <th><%= cv %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% parent_field.possible_values.each do |pv| %>
+      <tr>
+        <th><%= pv %></th>
+        <% custom_field.possible_values.each do |cv| %>
+          <% id = "dep_#{pv.parameterize}_#{cv.parameterize}" %>
+          <% checked = Array(custom_field.value_dependencies.to_h[pv.to_s]).include?(cv.to_s) %>
+          <td>
+            <%= check_box_tag "custom_field[value_dependencies][#{pv}][]", cv, checked, id: id %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% end %>

--- a/assets/javascripts/depending_custom_fields.js
+++ b/assets/javascripts/depending_custom_fields.js
@@ -1,0 +1,39 @@
+(function() {
+  function updateChild(parentSelect, childSelect, mapping) {
+    var parentValue = parentSelect.value;
+    var allowed = mapping[parentValue] || [];
+    var options = childSelect.querySelectorAll('option');
+    options.forEach(function(opt) {
+      if (opt.value === '') {
+        opt.hidden = false;
+      } else {
+        opt.hidden = allowed.length > 0 && allowed.indexOf(opt.value) === -1;
+      }
+    });
+    if (!parentValue) {
+      childSelect.disabled = true;
+      childSelect.value = '';
+    } else {
+      childSelect.disabled = false;
+      if (allowed.length > 0 && allowed.indexOf(childSelect.value) === -1) {
+        childSelect.value = '';
+      }
+    }
+    childSelect.dispatchEvent(new Event('change'));
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var data = window.DependingCustomFieldData || {};
+    Object.keys(data).forEach(function(cid) {
+      var info = data[cid];
+      var childSelect = document.getElementById('issue_custom_field_values_' + cid);
+      var parentSelect = document.getElementById('issue_custom_field_values_' + info.parent_id);
+      if (!childSelect || !parentSelect) { return; }
+      childSelect.classList.add('depending-child');
+      parentSelect.addEventListener('change', function() {
+        updateChild(parentSelect, childSelect, info.map || {});
+      });
+      updateChild(parentSelect, childSelect, info.map || {});
+    });
+  });
+})();

--- a/assets/stylesheets/depending_custom_fields.css
+++ b/assets/stylesheets/depending_custom_fields.css
@@ -1,0 +1,2 @@
+.dependencies-matrix th { text-align: left; }
+.depending-child { margin-left: 20px; }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -5,3 +5,6 @@ de:
   label_show_registered_users: "Registrierte Benutzer anzeigen"
   label_show_locked_users: "Inaktive Benutzer anzeigen"
   label_groups: "Gruppen"
+  label_dependable_list: "Liste (abhängig)"
+  label_dependable_enumeration: "Key/Value Liste (abhängig)"
+  field_parent_custom_field_id: "Abhängig von"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,6 @@ en:
   label_show_registered_users: "Show registered users"
   label_show_locked_users: "Show inactive users"
   label_groups: "Groups"
+  label_dependable_list: "List (dependable)"
+  label_dependable_enumeration: "Key/Value list (dependable)"
+  field_parent_custom_field_id: "Depends on"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,3 +5,6 @@ fr:
   label_show_registered_users: "Afficher les utilisateurs enregistrés"
   label_show_locked_users: "Afficher les utilisateurs inactifs"
   label_groups: "Groupes"
+  label_dependable_list: "Liste (dépendante)"
+  label_dependable_enumeration: "Liste clé/valeur (dépendante)"
+  field_parent_custom_field_id: "Dépend de"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -5,3 +5,6 @@ nl:
   label_show_registered_users: "Geregistreerde gebruikers tonen"
   label_show_locked_users: "Inactieve gebruikers tonen"
   label_groups: "Groepen"
+  label_dependable_list: "Lijst (afhankelijk)"
+  label_dependable_enumeration: "Sleutel/Waarde lijst (afhankelijk)"
+  field_parent_custom_field_id: "Afhankelijk van"

--- a/init.rb
+++ b/init.rb
@@ -6,7 +6,7 @@ Redmine::Plugin.register :redmine_depending_custom_fields do
   author 'Jan Catrysse'
   description 'Provides depending / cascading custom field formats that can be toggled via plugin settings.'
   url 'https://github.com/jcatrysse/redmine_depending_custom_fields'
-  version '0.0.2'
+  version '0.0.3'
   requires_redmine version_or_higher: '5.0'
 end
 
@@ -20,6 +20,7 @@ CustomField.safe_attributes(
   'show_active',
   'show_registered',
   'show_locked',
-  'parent_custom_field_id'
+  'parent_custom_field_id',
+  'value_dependencies'
 )
 

--- a/init.rb
+++ b/init.rb
@@ -6,7 +6,7 @@ Redmine::Plugin.register :redmine_depending_custom_fields do
   author 'Jan Catrysse'
   description 'Provides depending / cascading custom field formats that can be toggled via plugin settings.'
   url 'https://github.com/jcatrysse/redmine_depending_custom_fields'
-  version '0.0.1'
+  version '0.0.2'
   requires_redmine version_or_higher: '5.0'
 end
 
@@ -19,6 +19,7 @@ CustomField.safe_attributes(
   'exclude_admins',
   'show_active',
   'show_registered',
-  'show_locked'
+  'show_locked',
+  'parent_custom_field_id'
 )
 

--- a/lib/redmine_depending_custom_fields.rb
+++ b/lib/redmine_depending_custom_fields.rb
@@ -3,6 +3,7 @@
 require 'redmine'
 require_relative 'redmine_depending_custom_fields/extended_user_format'
 require_relative 'redmine_depending_custom_fields/dependable_list_format'
+require_relative 'redmine_depending_custom_fields/hooks/view_hooks'
 
 module RedmineDependingCustomFields
   FIELD_FORMAT_EXTENDED_USER = 'extended_user'

--- a/lib/redmine_depending_custom_fields.rb
+++ b/lib/redmine_depending_custom_fields.rb
@@ -2,9 +2,12 @@
 
 require 'redmine'
 require_relative 'redmine_depending_custom_fields/extended_user_format'
+require_relative 'redmine_depending_custom_fields/dependable_list_format'
 
 module RedmineDependingCustomFields
   FIELD_FORMAT_EXTENDED_USER = 'extended_user'
+  FIELD_FORMAT_DEPENDABLE_LIST = 'dependable_list'
+  FIELD_FORMAT_DEPENDABLE_ENUMERATION = 'dependable_enumeration'
 
   def self.register_formats
     formats = Setting.plugin_redmine_depending_custom_fields['enabled_formats'] || []
@@ -16,6 +19,26 @@ module RedmineDependingCustomFields
       end
     else
       Redmine::FieldFormat.delete FIELD_FORMAT_EXTENDED_USER
+    end
+
+    if formats.include?(FIELD_FORMAT_DEPENDABLE_LIST)
+      Redmine::FieldFormat.add FIELD_FORMAT_DEPENDABLE_LIST, DependableListFormat do |format|
+        format.label = :label_dependable_list
+        format.order = 9
+        format.edit_as = 'list'
+      end
+    else
+      Redmine::FieldFormat.delete FIELD_FORMAT_DEPENDABLE_LIST
+    end
+
+    if formats.include?(FIELD_FORMAT_DEPENDABLE_ENUMERATION)
+      Redmine::FieldFormat.add FIELD_FORMAT_DEPENDABLE_ENUMERATION, DependableEnumerationFormat do |format|
+        format.label = :label_dependable_enumeration
+        format.order = 10
+        format.edit_as = 'enumeration'
+      end
+    else
+      Redmine::FieldFormat.delete FIELD_FORMAT_DEPENDABLE_ENUMERATION
     end
   end
 end

--- a/lib/redmine_depending_custom_fields/dependable_list_format.rb
+++ b/lib/redmine_depending_custom_fields/dependable_list_format.rb
@@ -2,7 +2,7 @@ module RedmineDependingCustomFields
   class DependableListFormat < Redmine::FieldFormat::ListFormat
     add 'dependable_list'
     self.form_partial = 'custom_fields/formats/dependable_list'
-    field_attributes :parent_custom_field_id
+    field_attributes :parent_custom_field_id, :value_dependencies
 
     def label
       :label_dependable_list
@@ -17,12 +17,33 @@ module RedmineDependingCustomFields
         custom_field.parent_custom_field_id = parent&.id
       end
     end
+
+    def possible_values_options(custom_field, object = nil)
+      options = super
+      options.unshift(['', '']) unless options.any? { |o| (o.is_a?(Array) ? o[1] : o).to_s.blank? }
+
+      if object && custom_field.parent_custom_field_id.present?
+        parent = CustomField.find_by(id: custom_field.parent_custom_field_id)
+        if parent
+          parent_value = object.custom_field_value(parent)
+          mapping = custom_field.value_dependencies || {}
+          allowed = Array(mapping[parent_value.to_s])
+          if allowed.any?
+            options = options.select do |o|
+              val = o.is_a?(Array) ? o[1] : o
+              val.to_s.blank? || allowed.include?(val.to_s)
+            end
+          end
+        end
+      end
+      options
+    end
   end
 
   class DependableEnumerationFormat < Redmine::FieldFormat::EnumerationFormat
     add 'dependable_enumeration'
     self.form_partial = 'custom_fields/formats/dependable_enumeration'
-    field_attributes :parent_custom_field_id
+    field_attributes :parent_custom_field_id, :value_dependencies
 
     def label
       :label_dependable_enumeration
@@ -36,6 +57,27 @@ module RedmineDependingCustomFields
                                      field_format: ['enumeration', RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION])
         custom_field.parent_custom_field_id = parent&.id
       end
+    end
+
+    def possible_values_options(custom_field, object = nil)
+      options = super
+      options.unshift(['', '']) unless options.any? { |o| (o.is_a?(Array) ? o[1] : o).to_s.blank? }
+
+      if object && custom_field.parent_custom_field_id.present?
+        parent = CustomField.find_by(id: custom_field.parent_custom_field_id)
+        if parent
+          parent_value = object.custom_field_value(parent)
+          mapping = custom_field.value_dependencies || {}
+          allowed = Array(mapping[parent_value.to_s])
+          if allowed.any?
+            options = options.select do |o|
+              val = o.is_a?(Array) ? o[1] : o
+              val.to_s.blank? || allowed.include?(val.to_s)
+            end
+          end
+        end
+      end
+      options
     end
   end
 end

--- a/lib/redmine_depending_custom_fields/dependable_list_format.rb
+++ b/lib/redmine_depending_custom_fields/dependable_list_format.rb
@@ -1,0 +1,41 @@
+module RedmineDependingCustomFields
+  class DependableListFormat < Redmine::FieldFormat::ListFormat
+    add 'dependable_list'
+    self.form_partial = 'custom_fields/formats/dependable_list'
+    field_attributes :parent_custom_field_id
+
+    def label
+      :label_dependable_list
+    end
+
+    def before_custom_field_save(custom_field)
+      super
+      if custom_field.parent_custom_field_id.present?
+        parent = CustomField.find_by(id: custom_field.parent_custom_field_id.to_i,
+                                     type: custom_field.type,
+                                     field_format: ['list', RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST])
+        custom_field.parent_custom_field_id = parent&.id
+      end
+    end
+  end
+
+  class DependableEnumerationFormat < Redmine::FieldFormat::EnumerationFormat
+    add 'dependable_enumeration'
+    self.form_partial = 'custom_fields/formats/dependable_enumeration'
+    field_attributes :parent_custom_field_id
+
+    def label
+      :label_dependable_enumeration
+    end
+
+    def before_custom_field_save(custom_field)
+      super
+      if custom_field.parent_custom_field_id.present?
+        parent = CustomField.find_by(id: custom_field.parent_custom_field_id.to_i,
+                                     type: custom_field.type,
+                                     field_format: ['enumeration', RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION])
+        custom_field.parent_custom_field_id = parent&.id
+      end
+    end
+  end
+end

--- a/lib/redmine_depending_custom_fields/hooks/view_hooks.rb
+++ b/lib/redmine_depending_custom_fields/hooks/view_hooks.rb
@@ -1,0 +1,24 @@
+module RedmineDependingCustomFields
+  module Hooks
+    class ViewLayoutsBaseHtmlHeadHook < Redmine::Hook::ViewListener
+      def view_layouts_base_html_head(_context = {})
+        cfs = CustomField.where(field_format: [RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST,
+                                              RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION])
+        mapping = {}
+        cfs.each do |cf|
+          next unless cf.parent_custom_field_id.present?
+
+          mapping[cf.id.to_s] = {
+            parent_id: cf.parent_custom_field_id.to_s,
+            map: cf.value_dependencies || {}
+          }
+        end
+
+        script = "window.DependingCustomFieldData = #{mapping.to_json};"
+        javascript_include_tag('depending_custom_fields', plugin: 'redmine_depending_custom_fields') +
+          stylesheet_link_tag('depending_custom_fields', plugin: 'redmine_depending_custom_fields') +
+          javascript_tag(script)
+      end
+    end
+  end
+end

--- a/test/dependable_formats_test.rb
+++ b/test/dependable_formats_test.rb
@@ -1,0 +1,35 @@
+require_relative 'test_helper'
+
+class DependableFormatsTest < ActiveSupport::TestCase
+  def setup
+    @plugin_settings = Setting.plugin_redmine_depending_custom_fields
+  end
+
+  def teardown
+    Setting.plugin_redmine_depending_custom_fields = @plugin_settings
+  end
+
+  def test_list_format_registered_when_enabled
+    Setting.plugin_redmine_depending_custom_fields = {'enabled_formats' => [RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST]}
+    RedmineDependingCustomFields.register_formats
+    assert_includes Redmine::FieldFormat.available_formats, RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST
+  end
+
+  def test_list_format_not_registered_when_disabled
+    Setting.plugin_redmine_depending_custom_fields = {'enabled_formats' => []}
+    RedmineDependingCustomFields.register_formats
+    assert_not_includes Redmine::FieldFormat.available_formats, RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_LIST
+  end
+
+  def test_enumeration_format_registered_when_enabled
+    Setting.plugin_redmine_depending_custom_fields = {'enabled_formats' => [RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION]}
+    RedmineDependingCustomFields.register_formats
+    assert_includes Redmine::FieldFormat.available_formats, RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION
+  end
+
+  def test_enumeration_format_not_registered_when_disabled
+    Setting.plugin_redmine_depending_custom_fields = {'enabled_formats' => []}
+    RedmineDependingCustomFields.register_formats
+    assert_not_includes Redmine::FieldFormat.available_formats, RedmineDependingCustomFields::FIELD_FORMAT_DEPENDABLE_ENUMERATION
+  end
+end


### PR DESCRIPTION
## Summary
- fix error when loading dependency data by reading custom field attributes from format store
- ensure child fields keep blank option and disable descendants when ancestors are cleared

## Testing
- `bundle exec rake test` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_b_68547ee63488832387f0d9fb3d41664f